### PR TITLE
Add usePhones hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.1.2",
+    "@tanstack/react-query": "^5.66.9",
     "axios": "^1.8.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,22 @@
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import routes from "@/routes";
 import { LayoutSwitcher } from "@/layouts";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const queryClient = new QueryClient();
 
 function App() {
   return (
     <Router>
-      <LayoutSwitcher>
-        <Routes>
-          {routes.map((route, index) => (
-            <Route key={index} path={route.path} element={route.element} />
-          ))}
-        </Routes>
-      </LayoutSwitcher>
+      <QueryClientProvider client={queryClient}>
+        <LayoutSwitcher>
+          <Routes>
+            {routes.map((route, index) => (
+              <Route key={index} path={route.path} element={route.element} />
+            ))}
+          </Routes>
+        </LayoutSwitcher>
+      </QueryClientProvider>
     </Router>
   );
 }

--- a/src/hooks/phones/index.ts
+++ b/src/hooks/phones/index.ts
@@ -1,0 +1,1 @@
+export * from "./usePhones";

--- a/src/hooks/phones/usePhones.tsx
+++ b/src/hooks/phones/usePhones.tsx
@@ -2,12 +2,12 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { getPhones } from "@/lib/api/services/phoneService";
 
 import { removeDuplicatesById } from "@/lib/utils/removeDuplicatesById";
-import { IUsePhones } from "@/types/phone";
+import { IPhone, IUsePhones } from "@/types/phone";
 import { useEffect, useState } from "react";
 
 export const usePhones = (search: string, limit: number): IUsePhones => {
   const initialPageParam = 1;
-  const [previousPhones, setPreviousPhones] = useState<any[]>([]);
+  const [previousPhones, setPreviousPhones] = useState<IPhone[]>([]);
 
   const {
     error,

--- a/src/hooks/phones/usePhones.tsx
+++ b/src/hooks/phones/usePhones.tsx
@@ -1,0 +1,44 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { getPhones } from "@/lib/api/services/phoneService";
+
+import { removeDuplicatesById } from "@/lib/utils/removeDuplicatesById";
+import { IUsePhones } from "@/types/phone";
+import { useEffect, useState } from "react";
+
+export const usePhones = (search: string, limit: number): IUsePhones => {
+  const initialPageParam = 1;
+  const [previousPhones, setPreviousPhones] = useState<any[]>([]);
+
+  const {
+    error,
+    data: phones,
+    isLoading,
+    hasNextPage,
+    isFetching,
+    fetchNextPage,
+  } = useInfiniteQuery({
+    queryKey: ["phones", search, limit],
+    queryFn: ({ pageParam = initialPageParam }) =>
+      getPhones(search, pageParam, limit),
+    initialPageParam,
+    getNextPageParam: (lastPage, pages) => {
+      return lastPage.length === limit ? pages.length + 1 : undefined;
+    },
+  });
+
+  useEffect(() => {
+    if (phones) {
+      setPreviousPhones(removeDuplicatesById(phones.pages.flat()));
+    }
+  }, [phones]);
+
+  return {
+    phones: isFetching
+      ? previousPhones
+      : removeDuplicatesById(phones?.pages.flat() || []),
+    error,
+    isLoading,
+    hasNextPage,
+    fetchNextPage,
+  };
+};

--- a/src/lib/utils/removeDuplicatesById.ts
+++ b/src/lib/utils/removeDuplicatesById.ts
@@ -1,0 +1,10 @@
+export function removeDuplicatesById<T extends { id: string }>(
+  items: T[]
+): T[] {
+  const seen = new Set();
+  return items.filter((item) => {
+    const duplicate = seen.has(item.id);
+    seen.add(item.id);
+    return !duplicate;
+  });
+}

--- a/src/types/phone.ts
+++ b/src/types/phone.ts
@@ -1,3 +1,5 @@
+import { PaginatedQuery } from "./query";
+
 export interface IPhone {
   id: string;
   name: string;
@@ -35,4 +37,8 @@ export interface IPhoneDetails extends Omit<IPhone, "imageUrl"> {
   specs: IPhoneSpecs;
   storageOptions: IPhoneStorageOptions[];
   similarProducts: IPhone[];
+}
+
+export interface IUsePhones extends PaginatedQuery {
+  phones: IPhone[];
 }

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -1,0 +1,9 @@
+export interface Query {
+  isLoading: boolean;
+  error: any;
+}
+
+export interface PaginatedQuery extends Query {
+  hasNextPage: boolean;
+  fetchNextPage: () => void;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1013,6 +1013,18 @@
     lightningcss "^1.29.1"
     tailwindcss "4.0.9"
 
+"@tanstack/query-core@5.66.4":
+  version "5.66.4"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.66.4.tgz#44b87bff289466adbfa0de8daa5756cbd2d61c61"
+  integrity sha512-skM/gzNX4shPkqmdTCSoHtJAPMTtmIJNS0hE+xwTTUVYwezArCT34NMermABmBVUg5Ls5aiUXEDXfqwR1oVkcA==
+
+"@tanstack/react-query@^5.66.9":
+  version "5.66.9"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.66.9.tgz#1c8be303adae59e9cee877490fbb2c23dfa26927"
+  integrity sha512-NRI02PHJsP5y2gAuWKP+awamTIBFBSKMnO6UVzi03GTclmHHHInH5UzVgzi5tpu4+FmGfsdT7Umqegobtsp23A==
+  dependencies:
+    "@tanstack/query-core" "5.66.4"
+
 "@testing-library/dom@^10.4.0":
   version "10.4.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.4.0.tgz#82a9d9462f11d240ecadbf406607c6ceeeff43a8"


### PR DESCRIPTION
## Problem/Feature
We need a way to fetch data from the App based on the entity. 

## Solution
- Create a usePhones custom hook to retrieve a list of phones

## Testing Steps
- Run `yarn dev`
- Copy this into the pages/Phones.ts file:
```ts
import { usePhones } from "@/hooks/phones";

export const Phones: React.FC = () => {
  const { phones } = usePhones("", 10);

  return (
    <ul>
      {phones.map((phone) => (
        <li key={phone.id}>{phone.name}</li>
      ))}
    </ul>
  );
};
```

- You should see a list of phones

## Additional Information
Test aded in the follow-up PR