### PR TITLE
add usePhone hook

### DIFF
--- a/src/hooks/phones/usePhone.test.tsx
+++ b/src/hooks/phones/usePhone.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { useQuery } from "@tanstack/react-query";
 import { usePhone } from "./usePhone";
-import { IPhoneDetails } from "../../types/phone";
+import { IPhoneDetails } from "@/types/phone";
 import { mockPhoneFixture } from "@/test/__fixtures__/phones";
 
 jest.mock("@tanstack/react-query", () => ({

--- a/src/hooks/phones/usePhone.test.tsx
+++ b/src/hooks/phones/usePhone.test.tsx
@@ -1,0 +1,63 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { useQuery } from "@tanstack/react-query";
+import { usePhone } from "./usePhone";
+import { IPhoneDetails } from "../../types/phone";
+import { mockPhoneFixture } from "@/test/__fixtures__/phones";
+
+jest.mock("@tanstack/react-query", () => ({
+  useQuery: jest.fn(),
+}));
+
+jest.mock("../../../src/lib/api/services/phoneService", () => ({
+  getPhoneById: jest.fn(),
+}));
+
+describe("usePhone", () => {
+  it("should return phone data when query is successful", async () => {
+    const phoneData: IPhoneDetails = mockPhoneFixture;
+    (useQuery as jest.Mock).mockReturnValue({
+      data: phoneData,
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() => usePhone("1"));
+
+    await waitFor(() => {
+      expect(result.current.phone).toEqual(phoneData);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  it("should return loading state initially", () => {
+    (useQuery as jest.Mock).mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+    });
+
+    const { result } = renderHook(() => usePhone("1"));
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.phone).toEqual({});
+    expect(result.current.error).toBeNull();
+  });
+
+  it("should return error state when query fails", async () => {
+    const error = new Error("Failed to fetch");
+    (useQuery as jest.Mock).mockReturnValue({
+      data: null,
+      isLoading: false,
+      error,
+    });
+
+    const { result } = renderHook(() => usePhone("1"));
+
+    await waitFor(() => {
+      expect(result.current.error).toEqual(error);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.phone).toEqual({});
+    });
+  });
+});

--- a/src/hooks/phones/usePhone.tsx
+++ b/src/hooks/phones/usePhone.tsx
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { getPhoneById } from "@/lib/api/services/phoneService";
+import { IPhoneDetails, IUsePhone } from "@/types/phone";
+
+export const usePhone = (id: string): IUsePhone => {
+  const {
+    data: phone,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["phone", id],
+    queryFn: () => getPhoneById(id),
+    enabled: !!id,
+  });
+
+  return {
+    phone: phone || ({} as IPhoneDetails),
+    isLoading,
+    error,
+  };
+};

--- a/src/types/phone.ts
+++ b/src/types/phone.ts
@@ -1,4 +1,4 @@
-import { PaginatedQuery } from "./query";
+import { PaginatedQuery, Query } from "./query";
 
 export interface IPhone {
   id: string;
@@ -41,4 +41,8 @@ export interface IPhoneDetails extends Omit<IPhone, "imageUrl"> {
 
 export interface IUsePhones extends PaginatedQuery {
   phones: IPhone[];
+}
+
+export interface IUsePhone extends Query {
+  phone: IPhoneDetails;
 }


### PR DESCRIPTION
## Problem/Feature
We need a way to fetch data individually from the App based on the entity. 

## Solution
- Create a usePhone custom hook to retrieve a list of phones

## Testing Steps
- Run `yarn dev`
- Browse to `/phones/SMG-A25`
- Copy this into the pages/PhoneDetails.ts file:
```ts
import { usePhone } from "@/hooks/phones/usePhone";

export const PhoneDetails: React.FC = () => {
  const { phone } = usePhone("SMG-A25");
  return <div>{JSON.stringify(phone)}</div>;
};

```

- You should see the phone details

## Additional Information
N/A
