### PR TITLE
Add PhoneSearch component

### DIFF
--- a/src/components/atoms/Input.tsx
+++ b/src/components/atoms/Input.tsx
@@ -4,7 +4,7 @@ interface InputProps {
   ariaLabel: string;
   initialValue?: string;
   name: string;
-  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange: (inputValue: string) => void;
   onClear: () => void;
   placeholder?: string;
   type?: string;
@@ -27,8 +27,8 @@ export const Input = ({
   };
 
   const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setInputValue(event.target.value);
-    onChange(event);
+    setInputValue(event.target.value || "");
+    onChange(event.target.value || "");
   };
 
   return (

--- a/src/components/molecules/PhoneSearch.test.tsx
+++ b/src/components/molecules/PhoneSearch.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { PhoneSearch } from "@/components/molecules/PhoneSearch";
+
+jest.mock("@/components/atoms/ResultsAmount", () => ({
+  ResultsAmount: jest.fn(() => <div>Mocked ResultsAmount</div>),
+}));
+
+describe("PhoneSearch", () => {
+  beforeEach(() => {
+    render(<PhoneSearch />);
+  });
+
+  it("renders correctly", () => {
+    expect(screen.getByPlaceholderText("Search phones")).toBeInTheDocument();
+    expect(screen.getByText("Mocked ResultsAmount")).toBeInTheDocument();
+  });
+
+  it("handles input change", () => {
+    const input = screen.getByPlaceholderText("Search phones...");
+
+    fireEvent.change(input, { target: { value: "test" } });
+    expect(input).toHaveValue("test");
+  });
+
+  it("handles clear search", () => {
+    const input = screen.getByPlaceholderText("Search phones");
+
+    fireEvent.change(input, { target: { value: "test" } });
+    fireEvent.change(input, { target: { value: "" } });
+    expect(input).toHaveValue("");
+  });
+});

--- a/src/components/molecules/PhoneSearch.tsx
+++ b/src/components/molecules/PhoneSearch.tsx
@@ -1,0 +1,29 @@
+import { Input } from "@/components/atoms/Input";
+import { ResultsAmount } from "../atoms/ResultsAmount";
+
+export const PhoneSearch = () => {
+  const handleInputChange = (inputValue: string) => {
+    console.log(inputValue);
+  };
+
+  const handleClearSearch = () => {
+    console.log("");
+  };
+
+  const resultsAmount = 10;
+
+  return (
+    <div className="w-full flex flex-col items-start sticky pt-1 z-10 bg-white">
+      <Input
+        onChange={handleInputChange}
+        onClear={handleClearSearch}
+        placeholder="Search phones..."
+        name="search"
+        ariaLabel="Search phones"
+        type={""}
+      />
+
+      {!!resultsAmount && <ResultsAmount resultsAmount={resultsAmount} />}
+    </div>
+  );
+};


### PR DESCRIPTION
## Problem/Feature
Users need a way to write down the phones they want to search for

## Solution
- Add PhoneSearch component

## Testing Steps
- Run yarn dev
- Copy this into you /pages/Phone.tsx file
```ts
import { PhoneSearch } from "@/components/molecules/PhoneSearch";

export const Phones: React.FC = () => {
  return <PhoneSearch />;
};
```
## Additional Information
This component will be revisited once the searching logic is implemented
