### PR TITLE
Add Search context and use it in PhoneSearch component

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "react-dom": "^19.0.0",
     "react-router-dom": "6",
     "tailwind-merge": "^3.0.1",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "use-debounce": "^10.0.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import routes from "@/routes";
 import { LayoutSwitcher } from "@/layouts";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { SearchProvider } from "@/contexts";
 
 const queryClient = new QueryClient();
 
@@ -9,13 +10,15 @@ function App() {
   return (
     <Router>
       <QueryClientProvider client={queryClient}>
-        <LayoutSwitcher>
-          <Routes>
-            {routes.map((route, index) => (
-              <Route key={index} path={route.path} element={route.element} />
-            ))}
-          </Routes>
-        </LayoutSwitcher>
+        <SearchProvider>
+          <LayoutSwitcher>
+            <Routes>
+              {routes.map((route, index) => (
+                <Route key={index} path={route.path} element={route.element} />
+              ))}
+            </Routes>
+          </LayoutSwitcher>
+        </SearchProvider>
       </QueryClientProvider>
     </Router>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import routes from "@/routes";
 import { LayoutSwitcher } from "@/layouts";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { SearchProvider } from "@/contexts";
+import { Navbar } from "./components/organisms";
 
 const queryClient = new QueryClient();
 
@@ -11,6 +12,7 @@ function App() {
     <Router>
       <QueryClientProvider client={queryClient}>
         <SearchProvider>
+          <Navbar />
           <LayoutSwitcher>
             <Routes>
               {routes.map((route, index) => (

--- a/src/components/atoms/BackButton.tsx
+++ b/src/components/atoms/BackButton.tsx
@@ -12,9 +12,12 @@ export const BackButton = () => {
   return (
     <button
       onClick={handleClick}
+      type="button"
       className="flex items-center w-[56px] h-[20px] text-xs cursor-pointer justify-between"
+      aria-label="Back to previous page"
+      title="Back"
     >
-      <ChevronLeft strokeWidth={1} size={18} />
+      <ChevronLeft strokeWidth={1} size={18} aria-hidden="true" />
       <span>{TEXTS.navbar.back.toUpperCase()}</span>
     </button>
   );

--- a/src/components/molecules/PhoneSearch.tsx
+++ b/src/components/molecules/PhoneSearch.tsx
@@ -1,17 +1,19 @@
 import { Input } from "@/components/atoms/Input";
 import { ResultsAmount } from "@/components/atoms/ResultsAmount";
 import { TEXTS } from "@/constants";
+import { SearchContext } from "@/contexts";
+import { use } from "react";
 
 export const PhoneSearch = () => {
+  const { debouncedSearch, resultsAmount, searchValue } = use(SearchContext);
+
   const handleInputChange = (inputValue: string) => {
-    console.log(inputValue);
+    debouncedSearch(inputValue);
   };
 
   const handleClearSearch = () => {
-    console.log("");
+    debouncedSearch("");
   };
-
-  const resultsAmount = 10;
 
   return (
     <div className="w-full flex flex-col items-start sticky pt-1 z-10 bg-white">
@@ -22,6 +24,7 @@ export const PhoneSearch = () => {
         name="search"
         ariaLabel="Search phones"
         type={""}
+        initialValue={searchValue}
       />
 
       {!!resultsAmount && <ResultsAmount resultsAmount={resultsAmount} />}

--- a/src/components/organisms/Navbar.test.tsx
+++ b/src/components/organisms/Navbar.test.tsx
@@ -1,6 +1,6 @@
 import { render } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { NavBar } from "./Navbar";
+import { Navbar } from "./Navbar";
 
 jest.mock("lucide-react", () => ({
   ShoppingCart: jest.fn(() => "shopping-cart"),
@@ -9,11 +9,11 @@ jest.mock("lucide-react", () => ({
 
 jest.mock("@/assets/logo.svg", () => "mock-logo");
 
-describe("NavBar", () => {
+describe("Navbar", () => {
   it("renders logo and shopping cart link", () => {
     const { getByAltText, getByRole } = render(
       <MemoryRouter initialEntries={["/phones"]}>
-        <NavBar />
+        <Navbar />
       </MemoryRouter>,
     );
 
@@ -24,7 +24,7 @@ describe("NavBar", () => {
   it("renders PhoneSearch component on /phones route", () => {
     const { getByPlaceholderText } = render(
       <MemoryRouter initialEntries={["/phones"]}>
-        <NavBar />
+        <Navbar />
       </MemoryRouter>,
     );
 
@@ -34,7 +34,7 @@ describe("NavBar", () => {
   it("renders BackButton component on non-/phones route", () => {
     const { getByRole } = render(
       <MemoryRouter initialEntries={["/other"]}>
-        <NavBar />
+        <Navbar />
       </MemoryRouter>,
     );
 

--- a/src/components/organisms/Navbar.tsx
+++ b/src/components/organisms/Navbar.tsx
@@ -4,7 +4,7 @@ import { useLocation } from "react-router-dom";
 import { PhoneSearch } from "@/components/molecules";
 import { BackButton } from "@/components/atoms";
 
-export const NavBar = () => {
+export const Navbar = () => {
   const location = useLocation();
 
   const isPhonesPage = location.pathname === "/phones";

--- a/src/contexts/SearchContext.test.tsx
+++ b/src/contexts/SearchContext.test.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { render, act } from "@testing-library/react";
+import { SearchProvider, SearchContext } from "./SearchContext";
+import { SearchContextProps } from "@/types";
+
+jest.mock("use-debounce", () => ({
+  useDebouncedCallback: (callback: (...args: unknown[]) => unknown) =>
+    jest.fn(callback),
+}));
+
+describe("SearchProvider", () => {
+  const TestConsumer: React.FC<{
+    onContext: (context: SearchContextProps) => void;
+  }> = ({ onContext }) => (
+    <SearchContext.Consumer>
+      {(context) => {
+        onContext(context);
+        return null;
+      }}
+    </SearchContext.Consumer>
+  );
+
+  it("renders children correctly", () => {
+    const { getByText } = render(
+      <SearchProvider>
+        <div>Test Child</div>
+      </SearchProvider>,
+    );
+
+    expect(getByText("Test Child")).toBeInTheDocument();
+  });
+
+  it("provides the correct initial context values", () => {
+    let contextValues: SearchContextProps | undefined;
+
+    render(
+      <SearchProvider>
+        <TestConsumer
+          onContext={(context) => {
+            contextValues = context;
+          }}
+        />
+      </SearchProvider>,
+    );
+
+    expect(contextValues).toEqual({
+      searchValue: "",
+      debouncedSearch: expect.any(Function),
+      resultsAmount: 0,
+      setResultsAmount: expect.any(Function),
+    });
+  });
+
+  it("updates searchValue when debouncedSearch is called", () => {
+    let contextValues: SearchContextProps | undefined;
+
+    render(
+      <SearchProvider>
+        <TestConsumer
+          onContext={(context) => {
+            contextValues = context;
+          }}
+        />
+      </SearchProvider>,
+    );
+
+    act(() => {
+      contextValues!.debouncedSearch("test search");
+    });
+
+    expect(contextValues!.searchValue).toBe("test search");
+  });
+
+  it("updates resultsAmount when setResultsAmount is called", () => {
+    let contextValues: SearchContextProps | undefined;
+
+    render(
+      <SearchProvider>
+        <TestConsumer
+          onContext={(context) => {
+            contextValues = context;
+          }}
+        />
+      </SearchProvider>,
+    );
+
+    act(() => {
+      contextValues!.setResultsAmount(10);
+    });
+
+    expect(contextValues!.resultsAmount).toBe(10);
+  });
+});

--- a/src/contexts/SearchContext.tsx
+++ b/src/contexts/SearchContext.tsx
@@ -1,0 +1,37 @@
+import { SearchContextProps } from "@/types";
+import { createContext, useState } from "react";
+import { DebouncedState, useDebouncedCallback } from "use-debounce";
+
+export const SearchContext = createContext<SearchContextProps>({
+  searchValue: "",
+  debouncedSearch: (() => {
+    const callback = () => {};
+    callback.cancel = () => {};
+    callback.flush = () => {};
+    callback.isPending = () => false;
+    return callback;
+  })() as DebouncedState<(value: string) => void>,
+  resultsAmount: 0,
+  setResultsAmount: () => {},
+});
+
+export const SearchProvider = ({ children }: { children: React.ReactNode }) => {
+  const [searchValue, setSearchValue] = useState("");
+  const [resultsAmount, setResultsAmount] = useState(0);
+
+  const debouncedSearch = useDebouncedCallback(
+    (value: string) => {
+      setSearchValue(value);
+    },
+    500,
+    { leading: false, trailing: true },
+  );
+
+  return (
+    <SearchContext.Provider
+      value={{ searchValue, debouncedSearch, resultsAmount, setResultsAmount }}
+    >
+      {children}
+    </SearchContext.Provider>
+  );
+};

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,0 +1,1 @@
+export * from "./SearchContext";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,4 @@
 export * from "./layout";
 export * from "./phone";
+export * from "./query";
+export * from "./search-context";

--- a/src/types/search-context.ts
+++ b/src/types/search-context.ts
@@ -1,0 +1,8 @@
+import { DebouncedState } from "use-debounce";
+
+export interface SearchContextProps {
+  searchValue: string;
+  debouncedSearch: DebouncedState<(value: string) => void>;
+  resultsAmount: number;
+  setResultsAmount: React.Dispatch<React.SetStateAction<number>>;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4155,6 +4155,11 @@ url-parse@^1.5.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
+use-debounce@^10.0.4:
+  version "10.0.4"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-10.0.4.tgz#2135be498ad855416c4495cfd8e0e130bd33bb24"
+  integrity sha512-6Cf7Yr7Wk7Kdv77nnJMf6de4HuDE4dTxKij+RqE9rufDsI6zsbjyAxcH5y2ueJCQAnfgKbzXbZHYlkFwmBlWkw==
+
 v8-to-istanbul@^9.0.1:
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz#b9572abfa62bd556c16d75fdebc1a411d5ff3175"


### PR DESCRIPTION
## Problem/Feature
We need a way to share some search functionalities across components

## Solution
- Create Search Context

## Testing Steps
- Run `yarn dev`
- Copy this into you /pages/Phone.tsx file
```ts
import { SearchContext } from "@/contexts";
import { usePhones } from "@/hooks/phones";
import { use } from "react";

export const Phones: React.FC = () => {
  const { searchValue } = use(SearchContext);
  const { phones } = usePhones(searchValue, 20);

  console.log(phones);

  return (
    <div>
      <p>{phones.length > 0 && phones[0].name}</p>
    </div>
  );
};

```

- Do a search
- You should see the name of the first phone in the response on the main page

## Additional Information
Improve BackButton accessibility 
