### PR TITLE
Add PhoneGrid component

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.475.0",
+    "motion": "^12.4.7",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "6",

--- a/src/components/atoms/BackButton/BackButton.test.tsx
+++ b/src/components/atoms/BackButton/BackButton.test.tsx
@@ -10,10 +10,6 @@ jest.mock("react-router-dom", () => ({
   useNavigate: () => mockNavigate,
 }));
 
-jest.mock("lucide-react", () => ({
-  ChevronLeft: jest.fn(() => "logo"),
-}));
-
 const backButtonText = TEXTS.navbar.back.toUpperCase();
 
 describe("BackButton", () => {
@@ -27,7 +23,7 @@ describe("BackButton", () => {
 
   it("renders correctly", () => {
     expect(screen.getByText(backButtonText)).toBeInTheDocument();
-    expect(screen.getByText("logo")).toBeInTheDocument();
+    expect(screen.getByText("ChevronLeft logo")).toBeInTheDocument();
   });
 
   it("navigates back when clicked", () => {

--- a/src/components/atoms/Image/Image.tsx
+++ b/src/components/atoms/Image/Image.tsx
@@ -14,18 +14,16 @@ const Image = ({
   handleOnError,
 }: ImageProps) => {
   return (
-    <div>
-      <img
-        src={imageUrl}
-        alt={`${name} picture`}
-        className={className}
-        loading="lazy"
-        onLoad={handleOnLoad}
-        onError={handleOnError}
-        role="img"
-        aria-label={`${name} picture`}
-      />
-    </div>
+    <img
+      src={imageUrl}
+      alt={`${name} picture`}
+      className={className}
+      loading="lazy"
+      onLoad={handleOnLoad}
+      onError={handleOnError}
+      role="img"
+      aria-label={`${name} picture`}
+    />
   );
 };
 

--- a/src/components/molecules/PhoneCard/PhoneCard.test.tsx
+++ b/src/components/molecules/PhoneCard/PhoneCard.test.tsx
@@ -9,10 +9,6 @@ jest.mock("react-router-dom", () => ({
   useNavigate: () => mockNavigate,
 }));
 
-jest.mock("lucide-react", () => ({
-  ChevronLeft: () => <svg />,
-}));
-
 describe("PhoneCard", () => {
   let card: HTMLElement;
   let image: HTMLElement;

--- a/src/components/molecules/PhoneCard/PhoneCard.tsx
+++ b/src/components/molecules/PhoneCard/PhoneCard.tsx
@@ -25,7 +25,7 @@ export const PhoneCard = memo(({ phone }: { phone: IPhone }) => {
   };
 
   return (
-    <article
+    <div
       className="relative w-full bg-transparent overflow-hidden pt-[100%] aspect-square outline-1 group font-thin border-collapse"
       onClick={handleClick}
       onKeyDown={handleKeyPress}
@@ -40,6 +40,6 @@ export const PhoneCard = memo(({ phone }: { phone: IPhone }) => {
           <CardPhoneDetails brand={brand} name={name} basePrice={basePrice} />
         </div>
       </div>
-    </article>
+    </div>
   );
 });

--- a/src/components/molecules/PhoneSearch/PhoneSearch.test.tsx
+++ b/src/components/molecules/PhoneSearch/PhoneSearch.test.tsx
@@ -10,17 +10,16 @@ describe("PhoneSearch", () => {
     isPending: jest.fn(),
   });
 
-  const renderComponent = (contextValues = {}) => {
-    const defaultValues = {
-      debouncedSearch: mockDebouncedSearch,
-      resultsAmount: 0,
-      searchValue: "",
-      setResultsAmount: jest.fn(),
-      ...contextValues,
-    };
+  const defaultValues = {
+    debouncedSearch: mockDebouncedSearch,
+    resultsAmount: 0,
+    searchValue: "",
+    setResultsAmount: jest.fn(),
+  };
 
+  const renderComponent = (contextValues = {}) => {
     return render(
-      <SearchContext.Provider value={defaultValues}>
+      <SearchContext.Provider value={{ ...defaultValues, ...contextValues }}>
         <PhoneSearch />
       </SearchContext.Provider>,
     );
@@ -63,7 +62,7 @@ describe("PhoneSearch", () => {
   it("renders ResultsAmount when there are results", () => {
     renderComponent({ resultsAmount: 5 });
 
-    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getByText("5 RESULTS")).toBeInTheDocument();
   });
 
   it("does not render ResultsAmount when there are no results", () => {

--- a/src/components/organisms/Navbar/Navbar.test.tsx
+++ b/src/components/organisms/Navbar/Navbar.test.tsx
@@ -2,11 +2,6 @@ import { render } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { Navbar } from "./Navbar";
 
-jest.mock("lucide-react", () => ({
-  ShoppingCart: jest.fn(() => "shopping-cart"),
-  ChevronLeft: jest.fn(() => "back"),
-}));
-
 jest.mock("@/assets/logo.svg", () => "mock-logo");
 
 describe("Navbar", () => {

--- a/src/components/organisms/PhoneGrid/PhoneGrid.test.tsx
+++ b/src/components/organisms/PhoneGrid/PhoneGrid.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { PhonesGrid } from "./PhoneGrid";
+import { mockPhonesFixture } from "@/test/__fixtures__/phones";
+
+const mockNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockNavigate,
+}));
+
+describe("PhonesGrid", () => {
+  it("renders correctly with vertical display", async () => {
+    render(<PhonesGrid phones={mockPhonesFixture} />);
+
+    const phoneItems = await waitFor(() => screen.getAllByRole("article"));
+    expect(phoneItems).toHaveLength(mockPhonesFixture.length);
+  });
+
+  it("renders correctly with horizontal display", () => {
+    render(<PhonesGrid phones={mockPhonesFixture} isHorizontalDisplay />);
+
+    const phoneItems = screen.getAllByRole("article");
+    expect(phoneItems).toHaveLength(mockPhonesFixture.length);
+  });
+
+  it("has correct aria attributes", () => {
+    render(<PhonesGrid phones={mockPhonesFixture} />);
+
+    const list = screen.getByRole("list");
+    expect(list).toHaveAttribute("aria-label", "List of phones results");
+    expect(list).toHaveAttribute("tabIndex", "0");
+  });
+});

--- a/src/components/organisms/PhoneGrid/PhoneGrid.tsx
+++ b/src/components/organisms/PhoneGrid/PhoneGrid.tsx
@@ -1,0 +1,45 @@
+import { Reorder } from "motion/react";
+import { PhoneCard } from "@/components/molecules";
+import { IPhone } from "@/types/phone";
+
+export const PhonesGrid = ({
+  phones,
+  isHorizontalDisplay = false,
+}: {
+  phones: IPhone[];
+  isHorizontalDisplay?: boolean;
+}) => {
+  const horizontalStyle = `
+    grid grid-flow-col 
+    w-full 
+    gap-[1px] 
+    overflow-x-auto overflow-y-hidden
+    auto-cols-[275px] 
+    snap-x snap-mandatory 
+    scrollbar-thin scrollbar-track-transparent scrollbar-thumb-gray-400
+    pl-[1px] pr-[1px] pb-[1px] pt-[1px]
+  `;
+
+  const verticalStyle = `w-full lg:max-width-[1700px] 
+    mb-10 mt-1 pl-[1px] pr-[1px] pb-[1px] pt-[1px] 
+    grid  grid-cols-1 sm:grid-cols-3 lg:grid-cols-5 gap-[1px]`;
+
+  return (
+    <Reorder.Group
+      className={isHorizontalDisplay ? horizontalStyle : verticalStyle}
+      axis={isHorizontalDisplay ? "x" : "y"}
+      values={phones}
+      onReorder={() => {}}
+      role="list"
+      aria-label="List of phones results"
+      tabIndex={0}
+      as="section"
+    >
+      {phones.map((phone: IPhone) => (
+        <Reorder.Item key={phone.id} value={phone} as="article">
+          <PhoneCard phone={phone} />
+        </Reorder.Item>
+      ))}
+    </Reorder.Group>
+  );
+};

--- a/src/components/organisms/index.ts
+++ b/src/components/organisms/index.ts
@@ -1,1 +1,2 @@
 export * from "./Navbar/Navbar";
+export * from "./PhoneGrid/PhoneGrid";

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,1 +1,6 @@
 import "@testing-library/jest-dom";
+
+jest.mock("lucide-react", () => ({
+  ShoppingCart: jest.fn(() => "Shopping Cart logo"),
+  ChevronLeft: () => "ChevronLeft logo",
+}));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2258,6 +2258,15 @@ fraction.js@^4.3.7:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.3.7.tgz#06ca0085157e42fda7f9e726e79fefc4068840f7"
   integrity sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==
 
+framer-motion@^12.4.7:
+  version "12.4.7"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-12.4.7.tgz#52a9fe42852707bedbbbaa988d252a4a62dd58fa"
+  integrity sha512-VhrcbtcAMXfxlrjeHPpWVu2+mkcoR31e02aNSR7OUS/hZAciKa8q6o3YN2mA1h+jjscRsSyKvX6E1CiY/7OLMw==
+  dependencies:
+    motion-dom "^12.4.5"
+    motion-utils "^12.0.0"
+    tslib "^2.4.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -3378,6 +3387,26 @@ minimatch@^9.0.4:
   dependencies:
     brace-expansion "^2.0.1"
 
+motion-dom@^12.4.5:
+  version "12.4.5"
+  resolved "https://registry.yarnpkg.com/motion-dom/-/motion-dom-12.4.5.tgz#06116b5a091496654da0d67e40555abbd26068f6"
+  integrity sha512-Q2xmhuyYug1CGTo0jdsL05EQ4RhIYXlggFS/yPhQQRNzbrhjKQ1tbjThx5Plv68aX31LsUQRq4uIkuDxdO5vRQ==
+  dependencies:
+    motion-utils "^12.0.0"
+
+motion-utils@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/motion-utils/-/motion-utils-12.0.0.tgz#fabf79f4f1c818720a1b70f615e2a1768f396ac0"
+  integrity sha512-MNFiBKbbqnmvOjkPyOKgHUp3Q6oiokLkI1bEwm5QA28cxMZrv0CbbBGDNmhF6DIXsi1pCQBSs0dX8xjeER1tmA==
+
+motion@^12.4.7:
+  version "12.4.7"
+  resolved "https://registry.yarnpkg.com/motion/-/motion-12.4.7.tgz#e65478c3b7d6c4cd08fe43ae301f210553d53b5b"
+  integrity sha512-mhegHAbf1r80fr+ytC6OkjKvIUegRNXKLWNPrCN2+GnixlNSPwT03FtKqp9oDny1kNcLWZvwbmEr+JqVryFrcg==
+  dependencies:
+    framer-motion "^12.4.7"
+    tslib "^2.4.0"
+
 ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
@@ -4090,6 +4119,11 @@ ts-jest@^29.2.6:
     make-error "^1.3.6"
     semver "^7.7.1"
     yargs-parser "^21.1.1"
+
+tslib@^2.4.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
## Problem/Feature
We need a grid to display the phone items

## Solution
- Create PhoneGrid component

## Testing Steps
- Run `yarn dev`
- Copy this into you /pages/Phone.tsx file
```ts
import { PhonesGrid } from "@/components/organisms";
import { SearchContext } from "@/contexts";
import { usePhones } from "@/hooks/phones";
import { use } from "react";

export const Phones: React.FC = () => {
  const { searchValue } = use(SearchContext);
  const { phones } = usePhones(searchValue, 20);

  return <PhonesGrid phones={phones} />;
};

```
- You should see a grid with the phones
- Search a specific phone by name or brand and the grid results should change

## Additional Information
Improve tests and create a global mock for lucide-react components