### PR TITLE
Update Phone page to render a list of phones

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "motion": "^12.4.7",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-infinite-scroll-component": "^6.1.0",
+    "react-loading-skeleton": "^3.5.0",
     "react-router-dom": "6",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { LayoutSwitcher } from "@/layouts";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { SearchProvider } from "@/contexts";
 import { Navbar } from "./components/organisms";
+import "react-loading-skeleton/dist/skeleton.css";
 
 const queryClient = new QueryClient();
 

--- a/src/components/organisms/Navbar/Navbar.test.tsx
+++ b/src/components/organisms/Navbar/Navbar.test.tsx
@@ -2,8 +2,6 @@ import { render } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { Navbar } from "./Navbar";
 
-jest.mock("@/assets/logo.svg", () => "mock-logo");
-
 describe("Navbar", () => {
   it("renders logo and shopping cart link", () => {
     const { getByAltText, getByRole } = render(

--- a/src/components/organisms/PhoneGrid/PhoneGrid.tsx
+++ b/src/components/organisms/PhoneGrid/PhoneGrid.tsx
@@ -21,7 +21,7 @@ export const PhonesGrid = ({
   `;
 
   const verticalStyle = `w-full lg:max-width-[1700px] 
-    mb-10 mt-1 pl-[1px] pr-[1px] pb-[1px] pt-[1px] 
+    mt-1 pl-[1px] pr-[1px] pb-[1px] pt-[1px] 
     grid  grid-cols-1 sm:grid-cols-3 lg:grid-cols-5 gap-[1px]`;
 
   return (

--- a/src/layouts/FullContainerLayout.tsx
+++ b/src/layouts/FullContainerLayout.tsx
@@ -1,5 +1,7 @@
 import { PageLayoutProps } from "@/types";
 
 export const FullContainerLayout = ({ children }: PageLayoutProps) => {
-  return <div className="w-full px-1 lg:px-4 pb-1 mx-auto">{children}</div>;
+  return (
+    <div className="w-full px-1 lg:px-4 pb-1 lg:pb-2 mx-auto">{children}</div>
+  );
 };

--- a/src/lib/api/client.test.ts
+++ b/src/lib/api/client.test.ts
@@ -13,16 +13,6 @@ jest.mock("axios", () => ({
 
 import apiClient from "./client";
 
-jest.mock("@/config", () => {
-  return jest.fn((key: "VITE_API_BASE_URL" | "VITE_API_KEY") => {
-    const env = {
-      VITE_API_BASE_URL: "https://api.example.com",
-      VITE_API_KEY: "test-api-key",
-    };
-    return env[key];
-  });
-});
-
 describe("ApiClient", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -56,7 +46,7 @@ describe("ApiClient", () => {
       expect(mockedAxiosInstance.post).toHaveBeenCalledWith(
         "/test",
         { key: "value" },
-        config
+        config,
       );
       expect(response).toEqual("test");
     });
@@ -69,7 +59,7 @@ describe("ApiClient", () => {
       expect(mockedAxiosInstance.put).toHaveBeenCalledWith(
         "/test",
         { key: "value" },
-        config
+        config,
       );
       expect(response).toEqual("test");
     });

--- a/src/lib/api/services/phoneService.test.ts
+++ b/src/lib/api/services/phoneService.test.ts
@@ -13,16 +13,6 @@ jest.mock("@/lib/api/client", () => ({
   delete: jest.fn(),
 }));
 
-jest.mock("@/config", () => {
-  return jest.fn((key: "VITE_API_BASE_URL" | "VITE_API_KEY") => {
-    const env = {
-      VITE_API_BASE_URL: "https://api.example.com",
-      VITE_API_KEY: "test-api-key",
-    };
-    return env[key];
-  });
-});
-
 describe("phoneService", () => {
   describe("getPhones", () => {
     let result: IPhone[];
@@ -36,7 +26,7 @@ describe("phoneService", () => {
 
       it("should fetch phones with default parameters", async () => {
         expect(apiClient.get).toHaveBeenCalledWith(
-          "products?limit=20&offset=0"
+          "products?limit=20&offset=0",
         );
         expect(result).toEqual(mockPhonesFixture);
       });
@@ -51,7 +41,7 @@ describe("phoneService", () => {
 
       it("should fetch phones with search parameter", async () => {
         expect(apiClient.get).toHaveBeenCalledWith(
-          "products?limit=20&offset=0&search=test"
+          "products?limit=20&offset=0&search=test",
         );
         expect(result).toEqual(mockPhonesFixture);
       });

--- a/src/pages/Phones.test.tsx
+++ b/src/pages/Phones.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, act } from "@testing-library/react";
+import { Phones } from "@/pages/Phones";
+import { SearchContext } from "@/contexts/SearchContext";
+import { usePhones } from "@/hooks/phones/usePhones";
+import { mockPhonesFixture } from "@/test/__fixtures__/phones";
+
+jest.mock("@/hooks/phones/usePhones");
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: jest.fn(),
+}));
+
+const mockDebouncedSearch = Object.assign(jest.fn(), {
+  cancel: jest.fn(),
+  flush: jest.fn(),
+  isPending: jest.fn(),
+});
+
+const mockSetResultsAmount = jest.fn();
+
+const renderPhonesComponent = async ({
+  phones,
+  isLoading,
+  error,
+}: {
+  phones: typeof mockPhonesFixture;
+  isLoading: boolean;
+  error: Error | null;
+}) => {
+  (usePhones as jest.Mock).mockReturnValue({
+    phones,
+    error,
+    isLoading,
+    fetchNextPage: jest.fn(),
+    hasNextPage: false,
+  });
+
+  await act(async () => {
+    render(
+      <SearchContext.Provider
+        value={{
+          searchValue: "",
+          setResultsAmount: mockSetResultsAmount,
+          debouncedSearch: mockDebouncedSearch,
+          resultsAmount: 0,
+        }}
+      >
+        <Phones />
+      </SearchContext.Provider>,
+    );
+  });
+};
+
+//TODO: Update test to check renderings on loading and when loaded
+
+describe("Phones page", () => {
+  it("calls setResultsAmount when phones change", async () => {
+    await renderPhonesComponent({
+      phones: mockPhonesFixture,
+      isLoading: false,
+      error: null,
+    });
+
+    expect(mockSetResultsAmount).toHaveBeenCalledWith(mockPhonesFixture.length);
+  });
+
+  it("displays error message when there's an error", async () => {
+    await renderPhonesComponent({
+      phones: [],
+      isLoading: false,
+      error: new Error("Test error"),
+    });
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+  });
+});

--- a/src/pages/Phones.tsx
+++ b/src/pages/Phones.tsx
@@ -1,15 +1,49 @@
-import { PhoneCard } from "@/components/molecules/PhoneCard/PhoneCard";
-import { SearchContext } from "@/contexts";
-import { usePhones } from "@/hooks/phones";
-import { use } from "react";
+import { Suspense, useEffect, use } from "react";
+import { PhonesGrid } from "@/components/organisms";
+import { usePhones } from "@/hooks/phones/usePhones";
+import InfiniteScroll from "react-infinite-scroll-component";
+import { SearchContext } from "@/contexts/SearchContext";
+import Skeleton from "react-loading-skeleton";
+
+const SkeletonGrid = ({
+  className = "grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-[1px]",
+  height = "250px",
+  duration = 0.75,
+  length = 20,
+}) => (
+  <div className={className} aria-label="Grid skeleton loader">
+    {Array.from({ length }).map((_, index) => (
+      <Skeleton key={index} height={height} duration={duration} />
+    ))}
+  </div>
+);
 
 export const Phones: React.FC = () => {
-  const { searchValue } = use(SearchContext);
-  const { phones } = usePhones(searchValue, 20);
+  const { searchValue, setResultsAmount } = use(SearchContext);
+  const { phones, error, fetchNextPage, hasNextPage } = usePhones(
+    searchValue,
+    20,
+  );
+
+  useEffect(() => {
+    setResultsAmount(phones.length);
+  }, [phones, setResultsAmount]);
+
+  if (error) {
+    return "Something went wrong";
+  }
 
   return (
-    <div className="w-[250px] h-[250px] mt-3">
-      {phones.length > 0 && <PhoneCard phone={phones[0]} />}
-    </div>
+    <InfiniteScroll
+      className="mt-3"
+      dataLength={phones.length}
+      next={fetchNextPage}
+      hasMore={hasNextPage || false}
+      loader={<SkeletonGrid className="mt-0" length={1} />}
+    >
+      <Suspense fallback={<SkeletonGrid />}>
+        <PhonesGrid phones={phones} />
+      </Suspense>
+    </InfiniteScroll>
   );
 };

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -4,3 +4,15 @@ jest.mock("lucide-react", () => ({
   ShoppingCart: jest.fn(() => "Shopping Cart logo"),
   ChevronLeft: () => "ChevronLeft logo",
 }));
+
+jest.mock("@/config", () => {
+  return jest.fn((key: "VITE_API_BASE_URL" | "VITE_API_KEY") => {
+    const env = {
+      VITE_API_BASE_URL: "https://api.example.com",
+      VITE_API_KEY: "test-api-key",
+    };
+    return env[key];
+  });
+});
+
+jest.mock("@/assets/logo.svg", () => "mock-logo");

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -1,6 +1,6 @@
 export interface Query {
   isLoading: boolean;
-  error: any;
+  error: Error | null;
 }
 
 export interface PaginatedQuery extends Query {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3699,6 +3699,13 @@ react-dom@^19.0.0:
   dependencies:
     scheduler "^0.25.0"
 
+react-infinite-scroll-component@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-infinite-scroll-component/-/react-infinite-scroll-component-6.1.0.tgz#7e511e7aa0f728ac3e51f64a38a6079ac522407f"
+  integrity sha512-SQu5nCqy8DxQWpnUVLx7V7b7LcA37aM7tvoWjTLZp1dk6EJibM5/4EJKzOnl07/BsM1Y40sKLuqjCwwH/xV0TQ==
+  dependencies:
+    throttle-debounce "^2.1.0"
+
 react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
@@ -3708,6 +3715,11 @@ react-is@^18.0.0:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
+react-loading-skeleton@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/react-loading-skeleton/-/react-loading-skeleton-3.5.0.tgz#da2090355b4dedcad5c53cb3f0ed364e3a76d6ca"
+  integrity sha512-gxxSyLbrEAdXTKgfbpBEFZCO/P153DnqSCQau2+o6lNy1jgMRr2MmRmOzMmyrwSaSYLRB8g7b0waYPmUjz7IhQ==
 
 react-refresh@^0.14.2:
   version "0.14.2"
@@ -4070,6 +4082,11 @@ test-exclude@^6.0.0:
     "@istanbuljs/schema" "^0.1.2"
     glob "^7.1.4"
     minimatch "^3.0.4"
+
+throttle-debounce@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.3.0.tgz#fd31865e66502071e411817e241465b3e9c372e2"
+  integrity sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ==
 
 tmpl@1.0.5:
   version "1.0.5"


### PR DESCRIPTION
## Problem/Feature
Phone page should display a list of phones based on the search term

## Solution
- Update Phones component to consume PhoneGrid and usePhones
- Add Skeleton lib to manage loading states
- Add infinite scroll 

## Testing Steps
- Run yarn `dev`
- Browse to `/`
- You should see the grid of phones
- Make a search and se how the grid of phones is updated

![image](https://github.com/user-attachments/assets/583429d6-ffb7-4569-b968-d25b71bb9846)


## Additional Information
Config mock is now global