### PR TITLE
Add Phone details and image components

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "NODE_OPTIONS='--no-deprecation' jest"
+    "test": "NODE_OPTIONS='--no-deprecation' jest --silent"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.1.2",

--- a/src/components/atoms/PhoneImage/PhoneImage.test.tsx
+++ b/src/components/atoms/PhoneImage/PhoneImage.test.tsx
@@ -1,0 +1,18 @@
+import { render } from "@testing-library/react";
+import { PhoneDetailsImage } from "./PhoneImage";
+
+describe("PhoneDetailsImage", () => {
+  it("renders correctly with given props and styles", () => {
+    const { getByAltText, container } = render(
+      <PhoneDetailsImage imageUrl="test-url" name="test-name" />,
+    );
+
+    const image = getByAltText("test-name picture");
+
+    expect(image).toBeInTheDocument();
+    expect(image).toHaveAttribute("src", "test-url");
+    expect(container.firstChild).toHaveClass(
+      "w-[290px] h-[290px] lg:w-[510px] lg:h-[459px] flex items-center justify-center",
+    );
+  });
+});

--- a/src/components/atoms/PhoneImage/PhoneImage.tsx
+++ b/src/components/atoms/PhoneImage/PhoneImage.tsx
@@ -1,0 +1,19 @@
+import Image from "@/components/atoms/Image/Image";
+
+export const PhoneDetailsImage = ({
+  imageUrl,
+  name,
+}: {
+  imageUrl: string;
+  name: string;
+}) => {
+  return (
+    <div className="w-[290px] h-[290px] lg:w-[510px] lg:h-[459px] flex items-center justify-center">
+      <Image
+        imageUrl={imageUrl}
+        name={name}
+        className="max-w-full max-h-full object-contain"
+      />
+    </div>
+  );
+};

--- a/src/components/atoms/PhoneTitle/PhoneTitle.test.tsx
+++ b/src/components/atoms/PhoneTitle/PhoneTitle.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { PhoneTitle } from "./PhoneTitle";
+
+describe("PhoneTitle", () => {
+  it("renders title in uppercase", () => {
+    render(<PhoneTitle title="iPhone" price={999} isBasePrice={false} />);
+
+    const heading = screen.getByRole("heading");
+    const price = screen.getByLabelText("Phone price");
+
+    expect(heading).toHaveTextContent("IPHONE");
+    expect(price).toHaveTextContent("999 EUR");
+  });
+
+  it("renders price correctly when isBasePrice is true", () => {
+    render(<PhoneTitle title="iPhone" price={999} isBasePrice={true} />);
+
+    const price = screen.getByLabelText("Phone price");
+
+    expect(price).toHaveTextContent("From 999 EUR");
+  });
+});

--- a/src/components/atoms/PhoneTitle/PhoneTitle.tsx
+++ b/src/components/atoms/PhoneTitle/PhoneTitle.tsx
@@ -1,0 +1,22 @@
+interface PhoneDetailsTitleProps {
+  title: string;
+  price: number;
+  isBasePrice: boolean;
+}
+
+export const PhoneTitle = ({
+  title,
+  price,
+  isBasePrice,
+}: PhoneDetailsTitleProps) => {
+  return (
+    <div className="flex flex-col items-start w-full mb-4">
+      <h2 role="heading" className="text-2xl">
+        {title.toUpperCase()}
+      </h2>
+      <p aria-label="Phone price" className="text-xl">
+        {isBasePrice ? `From ${price} EUR` : `${price} EUR`}
+      </p>
+    </div>
+  );
+};


### PR DESCRIPTION
## Problem/Feature
In order to give detailed info about the phone we need to create several component. First we need to show the basic price and name of the phone along with an image

## Solution
- Create PhoneTitle components
- Create PhoneImage components
- 

## Testing Steps
- Run `yarn dev`
- Copy this into you /pages/PhoneDetails.tsx file
```ts
import { PhoneDetailsImage } from "@/components/atoms/PhoneImage/PhoneImage";
import { PhoneTitle } from "@/components/atoms/PhoneTitle/PhoneTitle";
import { usePhone } from "@/hooks/phones/usePhone";
import { useParams } from "react-router-dom";

export const PhoneDetails = () => {
  const { id = "" } = useParams<{ id: string }>();
  const { phone } = usePhone(id);

  if (!phone) {
    return <p className="text-red-500">Phone not found</p>;
  }

  return (
    <div>
      {phone.colorOptions?.length > 0 && (
        <>
          <PhoneDetailsImage
            imageUrl={phone.colorOptions[0].imageUrl}
            name={phone.name}
          />
          <PhoneTitle
            title={phone.name}
            price={phone.storageOptions[0]?.price || 0}
            isBasePrice
          />
        </>
      )}
    </div>
  );
};


```
- Browse to /phone/:id through /phones
- You should see the phone name and image

## Additional Information
N/A