### PR TITLE
Create AddPhoneButton comoponents

### DIFF
--- a/src/components/atoms/AddPhoneButton/AddPhoneButton.test.tsx
+++ b/src/components/atoms/AddPhoneButton/AddPhoneButton.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AddPhoneButton } from "./AddPhoneButton";
+import { TEXTS } from "@/constants";
+
+const mockHandleOnClick = jest.fn();
+
+describe("AddPhoneButton", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders button with correct text", () => {
+    render(
+      <AddPhoneButton handleOnClick={mockHandleOnClick} disabled={false} />,
+    );
+
+    expect(
+      screen.getByText(
+        TEXTS.addPhoneButton.addPhoneButtonMessage.toUpperCase(),
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("calls handleOnClick when button is clicked", () => {
+    render(
+      <AddPhoneButton handleOnClick={mockHandleOnClick} disabled={false} />,
+    );
+
+    const button = screen.getByRole("button", { name: /add phone to cart/i });
+    fireEvent.click(button);
+
+    expect(mockHandleOnClick).toHaveBeenCalled();
+  });
+
+  it("does not call handleOnClick when button is disabled", () => {
+    render(
+      <AddPhoneButton handleOnClick={mockHandleOnClick} disabled={true} />,
+    );
+
+    const button = screen.getByRole("button", { name: /add phone to cart/i });
+
+    fireEvent.click(button);
+    fireEvent.mouseDown(button);
+    fireEvent.keyPress(button, { key: "Enter", code: "Enter", charCode: 13 });
+
+    expect(mockHandleOnClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/atoms/AddPhoneButton/AddPhoneButton.tsx
+++ b/src/components/atoms/AddPhoneButton/AddPhoneButton.tsx
@@ -1,0 +1,31 @@
+import { Button } from "@/components/atoms";
+import { TEXTS } from "@/constants";
+
+export const AddPhoneButton = ({
+  handleOnClick,
+  disabled,
+}: {
+  handleOnClick: () => void;
+  disabled: boolean;
+}) => {
+  const handleKeyPress = (event: React.KeyboardEvent) => {
+    if (event.key === "Enter") {
+      handleOnClick();
+    }
+  };
+
+  const buttonText = TEXTS.addPhoneButton.addPhoneButtonMessage;
+
+  return (
+    <Button
+      variant="primary"
+      size="large"
+      onClick={handleOnClick}
+      disabled={disabled}
+      ariaLabel="Add phone to cart"
+      onKeyPress={handleKeyPress}
+    >
+      {buttonText.toUpperCase()}
+    </Button>
+  );
+};

--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -1,11 +1,12 @@
 interface ButtonProps {
   ariaLabel: string;
   children: React.ReactNode;
-  onClick: () => void;
-  size: "content" | "small" | "large";
-  variant: "default" | "primary" | "inverse" | "danger";
   className?: string;
   disabled?: boolean;
+  onClick: () => void;
+  onKeyPress?: (e: React.KeyboardEvent<HTMLButtonElement>) => void;
+  size: "content" | "small" | "large";
+  variant: "default" | "primary" | "inverse" | "danger";
 }
 
 export const Button: React.FC<ButtonProps> = ({
@@ -14,6 +15,7 @@ export const Button: React.FC<ButtonProps> = ({
   className = "",
   disabled = false,
   onClick,
+  onKeyPress,
   size,
   variant,
 }) => {
@@ -63,6 +65,7 @@ export const Button: React.FC<ButtonProps> = ({
       onClick={!disabled ? onClick : undefined}
       role="button"
       tabIndex={disabled ? -1 : 0}
+      onKeyDown={!disabled ? onKeyPress : undefined}
     >
       {children}
     </button>

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -10,7 +10,7 @@ export const TEXTS = {
     colorMesage: "color. pick your favourite.",
   },
   storagePicker: {
-    storageMessage: "storage ¿how much space do you need?.",
+    storageMessage: "storage ¿how much space do you need?",
   },
   addPhoneButton: {
     addPhoneButtonMessage: "add",

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -12,4 +12,7 @@ export const TEXTS = {
   storagePicker: {
     storageMessage: "storage ¿how much space do you need?.",
   },
+  addPhoneButton: {
+    addPhoneButtonMessage: "add",
+  },
 };


### PR DESCRIPTION
## Problem/Feature
Users have the ability to add phones to the cart

## Solution
- Create AddPhoneButton component

## Testing Steps
- Run `yarn dev`
- Copy this into you /pages/PhoneDetails.tsx file
```ts
import { PhoneDetailsImage } from "@/components/atoms/PhoneImage/PhoneImage";
import { PhoneTitle } from "@/components/atoms/PhoneTitle/PhoneTitle";
import { usePhone } from "@/hooks/phones/usePhone";
import { useParams } from "react-router-dom";
import { ColorPicker, StoragePicker } from "@/components/molecules";
import { AddPhoneButton } from "@/components/atoms/AddPhoneButton/AddPhoneButton";

export const PhoneDetails = () => {
  const { id = "" } = useParams<{ id: string }>();
  const { phone } = usePhone(id);

  return (
    <div>
      {phone.colorOptions?.length > 0 && (
        <>
          <PhoneDetailsImage
            imageUrl={phone.colorOptions[0].imageUrl}
            name={phone.name}
          />
          <PhoneTitle
            title={phone.name}
            price={phone.storageOptions[0]?.price || 0}
            isBasePrice
          />
          <ColorPicker
            activeColor={phone.colorOptions[0]}
            colorOptions={phone.colorOptions}
            onColorChange={() => {}}
          />

          <StoragePicker
            activeStorage={phone.storageOptions[0]}
            storageOptions={phone.storageOptions}
            onStorageChange={() => {}}
          />

          <AddPhoneButton handleOnClick={() => {}} disabled={false} />
        </>
      )}
    </div>
  );
};
```
- Browse to /phone/:id through /phones
- You should see the button at the bottom of the page along with the rest of the components

## Additional Information
Functionality of this component will be revisited once the cart logic is implemented