### PR TITLE
Add PhoneSelector component

### DIFF
--- a/src/components/atoms/PhoneImage/PhoneImage.test.tsx
+++ b/src/components/atoms/PhoneImage/PhoneImage.test.tsx
@@ -1,10 +1,10 @@
 import { render } from "@testing-library/react";
-import { PhoneDetailsImage } from "./PhoneImage";
+import { PhoneImage } from "./PhoneImage";
 
 describe("PhoneDetailsImage", () => {
   it("renders correctly with given props and styles", () => {
     const { getByAltText, container } = render(
-      <PhoneDetailsImage imageUrl="test-url" name="test-name" />,
+      <PhoneImage imageUrl="test-url" name="test-name" />,
     );
 
     const image = getByAltText("test-name picture");

--- a/src/components/atoms/PhoneImage/PhoneImage.tsx
+++ b/src/components/atoms/PhoneImage/PhoneImage.tsx
@@ -1,6 +1,6 @@
 import Image from "@/components/atoms/Image/Image";
 
-export const PhoneDetailsImage = ({
+export const PhoneImage = ({
   imageUrl,
   name,
 }: {

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -1,3 +1,4 @@
+export * from "./AddPhoneButton/AddPhoneButton";
 export * from "./BackButton/BackButton";
 export * from "./Button/Button";
 export * from "./CardPhoneDetails/CardPhoneDetails";

--- a/src/components/organisms/PhoneSelector/PhoneSelector.test.tsx
+++ b/src/components/organisms/PhoneSelector/PhoneSelector.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { PhoneSelector } from "./PhoneSelector";
+import { mockPhoneFixture } from "@/test/__fixtures__/phones";
+
+describe("PhoneSelector", () => {
+  beforeEach(() => {
+    render(<PhoneSelector phone={mockPhoneFixture} />);
+  });
+
+  it("renders phone image and title", () => {
+    expect(screen.getByAltText("Phone name picture")).toBeInTheDocument();
+    expect(screen.getByText("Phone name".toUpperCase())).toBeInTheDocument();
+  });
+
+  it("renders storage options", () => {
+    expect(screen.getByText("Phone storage")).toBeInTheDocument();
+    expect(screen.getByText("Phone storage 2")).toBeInTheDocument();
+  });
+
+  it("renders color options", () => {
+    expect(
+      screen.getByLabelText("Select color Phone color"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Select color Phone color 2"),
+    ).toBeInTheDocument();
+  });
+
+  it("enables add phone button when storage and color are selected", () => {
+    fireEvent.click(screen.getByText("Phone storage"));
+    fireEvent.click(screen.getByLabelText("Select color Phone color"));
+    expect(screen.getByRole("button", { name: /ADD/i })).toBeEnabled();
+  });
+});

--- a/src/components/organisms/PhoneSelector/PhoneSelector.tsx
+++ b/src/components/organisms/PhoneSelector/PhoneSelector.tsx
@@ -1,0 +1,76 @@
+import { AddPhoneButton, PhoneImage, PhoneTitle } from "@/components/atoms";
+import { ColorPicker, StoragePicker } from "@/components/molecules";
+import {
+  IPhoneColorOptions,
+  IPhoneDetails,
+  IPhoneStorageOptions,
+} from "@/types";
+import { useEffect, useState } from "react";
+
+interface PhoneSelectorProps {
+  phone: IPhoneDetails;
+}
+
+export const PhoneSelector = ({ phone }: PhoneSelectorProps) => {
+  const [storage, setStorage] = useState<IPhoneStorageOptions>({
+    capacity: "",
+    price: 0,
+  });
+
+  const [color, setColor] = useState<IPhoneColorOptions>({
+    name: "",
+    hexCode: "",
+    imageUrl: "",
+  });
+
+  const [isBasePrice, setIsBasePrice] = useState(true);
+  const [price, setPrice] = useState(0);
+
+  useEffect(() => {
+    if (phone && phone.storageOptions?.length > 0) {
+      setPrice(phone.storageOptions[0].price);
+    }
+  }, [phone]);
+
+  const handleColorChange = (colorOption: IPhoneColorOptions) => {
+    setColor(colorOption);
+  };
+
+  const handleStorageChange = (storage: IPhoneStorageOptions) => {
+    setIsBasePrice(false);
+    setStorage(storage);
+    setPrice(storage.price);
+    setColor(color);
+  };
+
+  return (
+    <section className="flex flex-col lg:flex-row items-center justify-between w-full mb-4 lg:mb-10 lg:mt-8">
+      <PhoneImage
+        imageUrl={color.imageUrl || phone.colorOptions[0]?.imageUrl}
+        name={phone.name}
+      />
+
+      <div className="flex flex-col w-full lg:w-[380px] lg:h-[459px] mt-1 lg:mt-0">
+        <PhoneTitle
+          title={phone.name}
+          price={price}
+          isBasePrice={isBasePrice}
+        />
+        <StoragePicker
+          storageOptions={phone.storageOptions}
+          activeStorage={storage}
+          onStorageChange={handleStorageChange}
+        />
+        <ColorPicker
+          colorOptions={phone.colorOptions}
+          onColorChange={handleColorChange}
+          activeColor={color}
+        />
+        <AddPhoneButton
+          handleOnClick={() => {}}
+          disabled={!(!!storage.capacity && !!color.name)}
+        />
+      </div>
+    </section>
+  );
+};

--- a/src/layouts/RestrictedContainerLayout.tsx
+++ b/src/layouts/RestrictedContainerLayout.tsx
@@ -1,5 +1,5 @@
 import { PageLayoutProps } from "@/types";
 
 export const RestrictedContainerLayout = ({ children }: PageLayoutProps) => {
-  return <div className="lg:w-[1200px] mx-auto">{children}</div>;
+  return <div className="lg:w-[1200px] mx-auto px-1 lg:px-0">{children}</div>;
 };

--- a/src/test/__fixtures__/phones.ts
+++ b/src/test/__fixtures__/phones.ts
@@ -22,7 +22,14 @@ export const mockPhoneFixture: IPhoneDetails = {
   name: "Phone name",
   brand: "Phone Brand",
   basePrice: 100,
-  colorOptions: [],
+  colorOptions: [
+    { name: "Phone color", hexCode: "Phone hex code", imageUrl: "Phone image" },
+    {
+      name: "Phone color 2",
+      hexCode: "Phone hex code 2",
+      imageUrl: "Phone image 2",
+    },
+  ],
   description: "Phone description",
   rating: 5,
   specs: {
@@ -35,6 +42,15 @@ export const mockPhoneFixture: IPhoneDetails = {
     os: "Phone OS",
     screenRefreshRate: "Phone screen refresh rate",
   },
-  storageOptions: [],
+  storageOptions: [
+    {
+      capacity: "Phone storage",
+      price: 100,
+    },
+    {
+      capacity: "Phone storage 2",
+      price: 200,
+    },
+  ],
   similarProducts: [],
 };


### PR DESCRIPTION
## Problem/Feature
Users can select the color and phone storage

## Solution
- Create ProductSelector comp

## Testing Steps
- Run `yarn dev`
- Copy this into you /pages/PhoneDetails.tsx file
```ts
import { usePhone } from "@/hooks/phones/usePhone";
import { useParams } from "react-router-dom";
import { PhoneSelector } from "@/components/organisms/PhoneSelector/PhoneSelector";

export const PhoneDetails = () => {
  const { id = "" } = useParams<{ id: string }>();
  const { phone } = usePhone(id);

  return (
    <div>
      {phone.colorOptions?.length > 0 && (
        <>
          <PhoneSelector phone={phone} />
        </>
      )}
    </div>
  );
};

```
- Browse to /phone/:id through /phones
- Play around with pickers

## Additional Information
N/A