### PR TITLE
Update phone details page to display phone

### DIFF
--- a/src/hooks/phones/usePhone.test.tsx
+++ b/src/hooks/phones/usePhone.test.tsx
@@ -1,11 +1,11 @@
 import { renderHook, waitFor } from "@testing-library/react";
-import { useQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { usePhone } from "./usePhone";
 import { IPhoneDetails } from "@/types/phone";
 import { mockPhoneFixture } from "@/test/__fixtures__/phones";
 
 jest.mock("@tanstack/react-query", () => ({
-  useQuery: jest.fn(),
+  useSuspenseQuery: jest.fn(),
 }));
 
 jest.mock("../../../src/lib/api/services/phoneService", () => ({
@@ -15,7 +15,7 @@ jest.mock("../../../src/lib/api/services/phoneService", () => ({
 describe("usePhone", () => {
   it("should return phone data when query is successful", async () => {
     const phoneData: IPhoneDetails = mockPhoneFixture;
-    (useQuery as jest.Mock).mockReturnValue({
+    (useSuspenseQuery as jest.Mock).mockReturnValue({
       data: phoneData,
       isLoading: false,
       error: null,
@@ -31,7 +31,7 @@ describe("usePhone", () => {
   });
 
   it("should return loading state initially", () => {
-    (useQuery as jest.Mock).mockReturnValue({
+    (useSuspenseQuery as jest.Mock).mockReturnValue({
       data: null,
       isLoading: true,
       error: null,
@@ -46,7 +46,7 @@ describe("usePhone", () => {
 
   it("should return error state when query fails", async () => {
     const error = new Error("Failed to fetch");
-    (useQuery as jest.Mock).mockReturnValue({
+    (useSuspenseQuery as jest.Mock).mockReturnValue({
       data: null,
       isLoading: false,
       error,

--- a/src/hooks/phones/usePhone.tsx
+++ b/src/hooks/phones/usePhone.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { getPhoneById } from "@/lib/api/services/phoneService";
 import { IPhoneDetails, IUsePhone } from "@/types/phone";
 
@@ -7,10 +7,9 @@ export const usePhone = (id: string): IUsePhone => {
     data: phone,
     isLoading,
     error,
-  } = useQuery({
+  } = useSuspenseQuery({
     queryKey: ["phone", id],
     queryFn: () => getPhoneById(id),
-    enabled: !!id,
   });
 
   return {

--- a/src/pages/PhoneDetails.test.tsx
+++ b/src/pages/PhoneDetails.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { PhoneDetails } from "./PhoneDetails";
+import { usePhone } from "@/hooks/phones/usePhone";
+import * as reactRouterDom from "react-router-dom";
+
+jest.mock("@/hooks/phones/usePhone");
+
+jest.mock("@/components/organisms/PhoneSelector/PhoneSelector", () => ({
+  PhoneSelector: () => <div data-testid="phone-selector">Phone Selector</div>,
+}));
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useParams: jest.fn(),
+}));
+
+//TODO: Update test to loading state
+
+const renderComponent = (id = "123") => {
+  (reactRouterDom.useParams as jest.Mock).mockReturnValue({ id });
+  return render(<PhoneDetails />);
+};
+
+describe("PhoneDetails", () => {
+  it("renders PhoneSelector when phone data is loaded successfully", async () => {
+    (usePhone as jest.Mock).mockReturnValue({
+      phone: { id: "123", name: "Test Phone" },
+      error: null,
+    });
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("phone-selector")).toBeInTheDocument();
+    });
+  });
+
+  it("renders error message when there is an error fetching phone data", async () => {
+    (usePhone as jest.Mock).mockReturnValue({
+      phone: null,
+      error: new Error("Failed to fetch"),
+    });
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/PhoneDetails.tsx
+++ b/src/pages/PhoneDetails.tsx
@@ -1,3 +1,54 @@
-export const PhoneDetails: React.FC = () => {
-  return <div>Phone Details</div>;
+import { usePhone } from "@/hooks/phones/usePhone";
+import { useParams } from "react-router-dom";
+import { PhoneSelector } from "@/components/organisms/PhoneSelector/PhoneSelector";
+import { Suspense } from "react";
+import Skeleton from "react-loading-skeleton";
+
+const SkeletonPhoneSelector = () => {
+  return (
+    <section className="flex flex-col lg:flex-row items-center justify-between w-full mb-4 lg:mb-10 lg:mt-8">
+      <Skeleton
+        width={300}
+        height={400}
+        className="lg:mr-8 width-[200px] lg:width-[300px]"
+      />
+
+      <div className="flex flex-col w-full lg:w-[380px] lg:h-[459px] mt-1 lg:mt-0">
+        <Skeleton height={30} width="80%" />
+        <Skeleton height={25} width="40%" />
+
+        <Skeleton height={50} width="100%" className="mt-4" />
+
+        <Skeleton height={50} width="100%" className="mt-4" />
+
+        <Skeleton height={45} width="100%" className="mt-6" />
+      </div>
+    </section>
+  );
+};
+
+const PhoneContent = ({ id }: { id: string }) => {
+  const { phone, error } = usePhone(id);
+
+  if (error) {
+    return <div>Something went wrong</div>;
+  }
+
+  return (
+    <>
+      <PhoneSelector phone={phone} />
+    </>
+  );
+};
+
+export const PhoneDetails = () => {
+  const { id = "" } = useParams<{ id: string }>();
+
+  return (
+    <div>
+      <Suspense fallback={<SkeletonPhoneSelector />}>
+        <PhoneContent id={id} />
+      </Suspense>
+    </div>
+  );
 };

--- a/src/test/__fixtures__/phones.ts
+++ b/src/test/__fixtures__/phones.ts
@@ -20,7 +20,7 @@ export const mockPhonesFixture: IPhone[] = [
 export const mockPhoneFixture: IPhoneDetails = {
   id: "1",
   name: "Phone name",
-  brand: "Phone Brand",
+  brand: "Phone brand",
   basePrice: 100,
   colorOptions: [
     { name: "Phone color", hexCode: "Phone hex code", imageUrl: "Phone image" },
@@ -52,5 +52,20 @@ export const mockPhoneFixture: IPhoneDetails = {
       price: 200,
     },
   ],
-  similarProducts: [],
+  similarProducts: [
+    {
+      id: "2",
+      name: "Similar product name",
+      brand: "Similar product brand",
+      imageUrl: "Similar product url",
+      basePrice: 100,
+    },
+    {
+      id: "3",
+      name: "Similar product 2 name",
+      brand: "Similar product 2 brand",
+      imageUrl: "Similar product 2 url",
+      basePrice: 200,
+    },
+  ],
 };


### PR DESCRIPTION
## Problem/Feature
Phone details page should display the phone image and phone selectors

## Solution
- Add components to Phone Details in order for it to display the phone

## Testing Steps
- Run `yarn dev`
- Browse to `/phones/:id`
- You should see the phone image and selectors

## Additional Information
In this PR the usePhone hook has been updated to use the Suspense query from tanstack/query