### PR TITLE
Add components to PhoneDetails page

### DIFF
--- a/src/pages/PhoneDetails.test.tsx
+++ b/src/pages/PhoneDetails.test.tsx
@@ -9,12 +9,25 @@ jest.mock("@/components/organisms/PhoneSelector/PhoneSelector", () => ({
   PhoneSelector: () => <div data-testid="phone-selector">Phone Selector</div>,
 }));
 
+jest.mock(
+  "@/components/organisms/SpecificationsTable/SpecificationsTable",
+  () => ({
+    SpecificationsTable: () => (
+      <div data-testid="specifications-table">Specifications Table</div>
+    ),
+  }),
+);
+
+jest.mock("@/components/organisms/SimilarProducts/SimilarProducts", () => ({
+  SimilarProducts: () => (
+    <div data-testid="similar-products">Similar Products</div>
+  ),
+}));
+
 jest.mock("react-router-dom", () => ({
   ...jest.requireActual("react-router-dom"),
   useParams: jest.fn(),
 }));
-
-//TODO: Update test to loading state
 
 const renderComponent = (id = "123") => {
   (reactRouterDom.useParams as jest.Mock).mockReturnValue({ id });
@@ -22,9 +35,16 @@ const renderComponent = (id = "123") => {
 };
 
 describe("PhoneDetails", () => {
-  it("renders PhoneSelector when phone data is loaded successfully", async () => {
+  it("renders PhoneSelector, SpecificationsTable, and SimilarProducts when phone data is loaded successfully", async () => {
     (usePhone as jest.Mock).mockReturnValue({
-      phone: { id: "123", name: "Test Phone" },
+      phone: {
+        id: "123",
+        name: "Test Phone",
+        specs: {},
+        brand: "Test Brand",
+        description: "Test Description",
+        similarProducts: [],
+      },
       error: null,
     });
 
@@ -32,6 +52,8 @@ describe("PhoneDetails", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("phone-selector")).toBeInTheDocument();
+      expect(screen.getByTestId("specifications-table")).toBeInTheDocument();
+      expect(screen.getByTestId("similar-products")).toBeInTheDocument();
     });
   });
 

--- a/src/pages/PhoneDetails.tsx
+++ b/src/pages/PhoneDetails.tsx
@@ -3,27 +3,40 @@ import { useParams } from "react-router-dom";
 import { PhoneSelector } from "@/components/organisms/PhoneSelector/PhoneSelector";
 import { Suspense } from "react";
 import Skeleton from "react-loading-skeleton";
+import { SimilarProducts, SpecificationsTable } from "@/components/organisms";
 
 const SkeletonPhoneSelector = () => {
   return (
-    <section className="flex flex-col lg:flex-row items-center justify-between w-full mb-4 lg:mb-10 lg:mt-8">
-      <Skeleton
-        width={300}
-        height={400}
-        className="lg:mr-8 width-[200px] lg:width-[300px]"
-      />
-
-      <div className="flex flex-col w-full lg:w-[380px] lg:h-[459px] mt-1 lg:mt-0">
-        <Skeleton height={30} width="80%" />
-        <Skeleton height={25} width="40%" />
-
-        <Skeleton height={50} width="100%" className="mt-4" />
-
-        <Skeleton height={50} width="100%" className="mt-4" />
-
-        <Skeleton height={45} width="100%" className="mt-6" />
-      </div>
-    </section>
+    <>
+      <section className="flex flex-col lg:flex-row items-center justify-between w-full mb-4 lg:mb-10 lg:mt-8">
+        <Skeleton
+          width={300}
+          height={400}
+          className="lg:mr-8 width-[200px] lg:width-[300px]"
+        />
+        <div className="flex flex-col w-full lg:w-[380px] lg:h-[459px] mt-1 lg:mt-0">
+          <Skeleton height={30} width="80%" />
+          <Skeleton height={25} width="40%" />
+          <Skeleton height={50} width="100%" className="mt-4" />
+          <Skeleton height={50} width="100%" className="mt-4" />
+          <Skeleton height={45} width="100%" className="mt-6" />
+        </div>
+      </section>
+      <section className="w-full mb-8">
+        <Skeleton height={30} width="60%" className="mb-2" />
+        <Skeleton height={20} width="100%" className="mb-1" />
+        <Skeleton height={20} width="100%" className="mb-1" />
+        <Skeleton height={20} width="100%" className="mb-1" />
+        <Skeleton height={20} width="100%" className="mb-1" />
+        <Skeleton height={20} width="100%" className="mb-1" />
+        <Skeleton height={20} width="100%" className="mb-1" />
+      </section>
+      <section className="w-full mb-1 lg:mb-8 flex">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <Skeleton key={index} width={150} height={200} />
+        ))}
+      </section>
+    </>
   );
 };
 
@@ -37,6 +50,17 @@ const PhoneContent = ({ id }: { id: string }) => {
   return (
     <>
       <PhoneSelector phone={phone} />
+      <section className="flex items-center justify-between w-full mb-8">
+        <SpecificationsTable
+          specs={phone.specs}
+          name={phone.name}
+          brand={phone.brand}
+          description={phone.description}
+        />
+      </section>
+      <section className="w-full overflow-scroll overflow-y-hidden overflow-x-scroll mb-1 lg:mb-8">
+        <SimilarProducts similarProducts={phone.similarProducts} />
+      </section>
     </>
   );
 };


### PR DESCRIPTION
## Problem/Feature
Users have to see the specifications table and similar products when visiting the phone details page

## Solution
- Add SimilarProducts to Phone details page
- Add SpecificationsTable to Phone details page

## Testing Steps
- Run `yarn dev`
- Browse to `/phone/:id`
- You should see the table of phone specifications and the similar products

## Additional Information
N/A